### PR TITLE
Fix GMP building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           echo "::set-output name=swigplk_version::$(python scripts/find_swiglpk_version.py)"
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.16.1
+        uses: joerick/cibuildwheel@v2.16.2
         env:
           NEW_GLPK_VERSION: ${{ steps.version.outputs.glpk_version }}
           GLPK_HEADER_PATH: glpk-${{ steps.version.outputs.glpk_version }}/src
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Get GLPK version
         id: version

--- a/config.sh
+++ b/config.sh
@@ -24,7 +24,7 @@ function pre_build {
         export CFLAGS="-I/usr/local/include $ADD_CFLAGS $CFLAGS"
         export LDFLAGS="-L/usr/local/lib $ARCHFLAGS"
         echo "Downloading GMP"
-        curl -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.lz
+        curl -O ftp://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.lz
         tar xzf gmp-$GMP_VERSION.tar.lz
         (cd gmp-$GMP_VERSION \
             && ./configure --prefix=$BUILD_PREFIX $ADD_CONFIG_FLAGS \

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ function pre_build {
     # Runs in the root directory of this repository.
     ADD_CFLAGS=""
     ADD_CONFIG_FLAGS=""
-    GMP_VERSION="6.3.0"  # hasn't changed in 2 years
+    GMP_VERSION="6.3.0"
     if [ -n "$IS_OSX" ]; then
         export CC=clang
         export CXX=clang++

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ function pre_build {
     # Runs in the root directory of this repository.
     ADD_CFLAGS=""
     ADD_CONFIG_FLAGS=""
-    GMP_VERSION="6.2.1"  # hasn't changed in 2 years
+    GMP_VERSION="6.3.0"  # hasn't changed in 2 years
     if [ -n "$IS_OSX" ]; then
         export CC=clang
         export CXX=clang++
@@ -24,7 +24,7 @@ function pre_build {
         export CFLAGS="-I/usr/local/include $ADD_CFLAGS $CFLAGS"
         export LDFLAGS="-L/usr/local/lib $ARCHFLAGS"
         echo "Downloading GMP"
-        curl -O https://gmplib.org/download/gmp/gmp-$GMP_VERSION.tar.lz
+        curl -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.lz
         tar xzf gmp-$GMP_VERSION.tar.lz
         (cd gmp-$GMP_VERSION \
             && ./configure --prefix=$BUILD_PREFIX $ADD_CONFIG_FLAGS \


### PR DESCRIPTION
Switching the download to ftp.gnu.org to avoid downloading from gmplib.org which does not like to be pummeled by Github requests.

Updates GMP to 6.3.0 as well, fixes #62.