### PR TITLE
Update builds and fix failing GMP download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: rm -rf glpk_build && python scripts/build_glpk.py
           CIBW_ARCHS_MACOS: "arm64 x86_64"
           CIBW_ARCHS_LINUX: "auto aarch64"
-          CIBW_SKIP: pp*-win* *-musllinux* cp36-*_aarch64 cp37-*_aarch64 pp*-*_aarch64
+          CIBW_SKIP: pp*-win* *-musllinux* cp36-* cp37-* pp*-*_aarch64 pp37* pp38*
           # install before tests
           CIBW_TEST_COMMAND: cp {project}/test_swiglpk.py . && python test_swiglpk.py
           CIBW_TEST_SKIP: "*_arm64"

--- a/config.sh
+++ b/config.sh
@@ -24,7 +24,7 @@ function pre_build {
         export CFLAGS="-I/usr/local/include $ADD_CFLAGS $CFLAGS"
         export LDFLAGS="-L/usr/local/lib $ARCHFLAGS"
         echo "Downloading GMP"
-        curl -O ftp://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.lz
+        curl -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.lz
         tar xzf gmp-$GMP_VERSION.tar.lz
         (cd gmp-$GMP_VERSION \
             && ./configure --prefix=$BUILD_PREFIX $ADD_CONFIG_FLAGS \


### PR DESCRIPTION
This updates the builds to only use recent Python versions and fixes the failing compilation on MacOS due to GMP downloads.

New supported Python versions are CPython 3.8+ and PyPy 3.9+ (fixes #94).