### PR TITLE
Fix the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
     # see https://docs.pypi.org/trusted-publishers/.
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: wheelhouse/
 
     - name: Create GitHub release
       if: needs.versions.outputs.glpk_version != needs.versions.outputs.swigplk_version


### PR DESCRIPTION
This fixes a bug introduced in #104 . Packages are now taken from the correct directory. Unfortunately, can only be tested with an actual release.