### PR TITLE
Fix the broken Linux ARM builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: source {project}/config.sh && IS_OSX=true pre_build
           CIBW_BEFORE_BUILD_WINDOWS: rm -rf glpk_build && python -m pip install setuptools && python scripts/build_glpk.py
           CIBW_ARCHS_MACOS: "arm64 x86_64"
-          CIBW_ARCHS_LINUX: "auto aarch64"
+          CIBW_ARCHS_LINUX: "auto"
           CIBW_SKIP: pp* *-musllinux* cp36-* cp37-*
           # install before tests
           CIBW_TEST_COMMAND: cp {project}/test_swiglpk.py . && python test_swiglpk.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13]
 
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -32,14 +32,8 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install swig -f -y
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.0
         env:
           NEW_GLPK_VERSION: ${{ inputs.glpk_version }}
           GLPK_HEADER_PATH: glpk-${{ inputs.glpk_version }}/src


### PR DESCRIPTION
Linux builds will fail to due to https://github.com/pypa/cibuildwheel/issues/2257 . This PR will test some mitigation strategies.